### PR TITLE
Fix onListenerRemoved() input parameters

### DIFF
--- a/include/CommonAPI/SomeIP/Event.hpp
+++ b/include/CommonAPI/SomeIP/Event.hpp
@@ -111,7 +111,7 @@ protected:
         proxy_.removeEventHandler(serviceId_, instanceId_, eventgroupId_, eventId_, handler_.get(), major, minor);
     }
 
-    virtual void onListenerRemoved(const Listener&) {
+    virtual void onListenerRemoved(const Listener&, const Subscription) {
 
     }
 


### PR DESCRIPTION
Should be matched with onListenerRemoved() in capicxx-core-runtime/include/CommonAPI/Event.h

Signed-off-by: Nikolay Khilyuk <nkh@ua.fm>