### PR TITLE
Fixing issue with union padding serialization

### DIFF
--- a/include/CommonAPI/SomeIP/OutputStream.hpp
+++ b/include/CommonAPI/SomeIP/OutputStream.hpp
@@ -264,7 +264,7 @@ public:
                 errorOccurred_ = true;
             } else {
                 for(size_t i = 0; i < paddingCount; i++) {
-                    _writeValue('\0', 8);
+                    _writeValue('\0', 1);
                 }
             }
         }


### PR DESCRIPTION
In the `CommonAPI::SomeIP::OutputStream` class, there is a bug in the `writeValue(...)` overload for serializing a `Variant`.

Essentially, in the case where it has to pad the serialized union because it has to have a fixed length, i.e.  `unionLengthWidth == 0`, the call to `_writeValue(const uint32_t &_value, const uint8_t &_width)` for adding the padding is incorrect because it passes in the number of bits to be serialized (`8`) for `width` when it should be passing in the number of bytes to be serialized (`1`), which is what the function is expecting. This causes the function to not add any padding because `8` is an invalid input for the `width` parameter. This PR changes the `8` to `1`. An alternative would be to use one of the `uint8_t` overloads of `_writeValue(...)` instead of the `uint32_t` overload.