### PR TITLE
Support reading and writing vector value with EmptyDeployment

### DIFF
--- a/include/CommonAPI/SomeIP/InputStream.hpp
+++ b/include/CommonAPI/SomeIP/InputStream.hpp
@@ -321,6 +321,29 @@ public:
         return (*this);
     }
 
+    template<typename ElementType_,
+        typename std::enable_if<(std::is_same<int8_t, ElementType_>::value ||
+                                 std::is_same<uint8_t, ElementType_>::value), int>::type = 0>
+    COMMONAPI_EXPORT InputStream &readValue(std::vector<ElementType_> &_value,
+            const EmptyDeployment *_depl) {
+        bitAlign();
+
+        (void)_depl;
+
+        uint32_t itsSize;
+
+        _value.clear();
+
+        errorOccurred_ = _readBitValue(itsSize, 32, false);
+
+        if (!hasError()) {
+            ElementType_ *base = reinterpret_cast<ElementType_ *>(_readRaw(itsSize));
+            _value.assign(base, base + itsSize);
+        }
+
+        return (*this);
+    }
+
     template<typename ElementType_, typename ElementDepl_,
         typename std::enable_if<(!std::is_same<int8_t, ElementType_>::value &&
                                  !std::is_same<uint8_t, ElementType_>::value), int>::type = 0>
@@ -376,6 +399,42 @@ public:
             }
 
 
+        }
+
+        return (*this);
+    }
+
+    template<typename ElementType_,
+        typename std::enable_if<(!std::is_same<int8_t, ElementType_>::value &&
+                                 !std::is_same<uint8_t, ElementType_>::value), int>::type = 0>
+    COMMONAPI_EXPORT InputStream &readValue(std::vector<ElementType_> &_value,
+                           const EmptyDeployment *_depl) {
+        bitAlign();
+
+        (void)_depl;
+
+        uint32_t itsSize;
+
+        _value.clear();
+
+        errorOccurred_ = _readBitValue(itsSize, 32, false);
+
+        while (itsSize > 0)
+        {
+            size_t remainingBeforeRead = remaining_;
+            ElementType_ itsElement;
+            readValue(itsElement, static_cast<EmptyDeployment *>(nullptr));
+            if (hasError()) {
+                break;
+            }
+
+            _value.push_back(std::move(itsElement));
+
+            itsSize -= uint32_t(remainingBeforeRead - remaining_);
+        }
+
+        if (itsSize != 0) {
+            errorOccurred_ = true;
         }
 
         return (*this);


### PR DESCRIPTION
It's about the compile error reported in GENIVI/capicxx-someip-tools#21.

Here is an example:

```fidl
struct ContentBase polymorphic {
}

struct Container {
    ContentBase content
}

struct ListContent extends ContentBase {
    UInt32 [] items
}
```

In the header file generated by the tools,  `ListContent` has methods to read and write its value with an `EmptyDeployment`:
```cpp
template<class _Input>
void readValue(CommonAPI::InputStream<_Input> &_input, const CommonAPI::EmptyDeployment *_depl) {
    (void) _depl;
    _input.template readValue<CommonAPI::EmptyDeployment>(std::get< 0>(values_));
}

template<class _Output>
void writeValue(CommonAPI::OutputStream<_Output> &_output, const CommonAPI::EmptyDeployment *_depl) {
    (void) _depl;
    _output.template writeValue<CommonAPI::EmptyDeployment>(std::get< 0>(values_));
}
```

However, none of the template methods of `InputStream` and `InputStream` matching the call, which should be like:
```cpp
// In InputStream.hpp
class InputStream: public CommonAPI::InputStream<InputStream> {
    // ...
    template<typename ElementType_>
    COMMONAPI_EXPORT InputStream &readValue(std::vector<ElementType_> &_value,
            const EmptyDeployment *_depl) {
        // ...
    }
    // ...
};

// In OutputStream.hpp
class OutputStream: public CommonAPI::OutputStream<OutputStream> {
    // ...
    template<typename ElementType_>
    COMMONAPI_EXPORT OutputStream &writeValue(const std::vector<ElementType_> &_value,
        const EmptyDeployment *_depl) {
        // ...
    }
    // ...
};
```

These template methods and their specialization for `std::vector<int8_t>` and `std::vector<uint8_t>` were added in the commit.

I've tested the changes with a simple example, no compile error any more and it works properly.